### PR TITLE
Freeze version of cyptominisat

### DIFF
--- a/APS_Optimizer_V3/Services/CryptoMiniSatDownloader.cs
+++ b/APS_Optimizer_V3/Services/CryptoMiniSatDownloader.cs
@@ -6,7 +6,7 @@ namespace APS_Optimizer_V3.Services;
 
 public class CryptoMiniSatDownloader
 {
-    private const string GITHUB_API_URL = "https://api.github.com/repos/msoos/cryptominisat/releases/latest";
+    private const string GITHUB_API_URL = "https://api.github.com/repos/msoos/cryptominisat/releases/tags/release/5.13.0";
     private const string WINDOWS_EXE_NAME = "cryptominisat5.exe";
     private const string LINUX_EXE_NAME = "cryptominisat5";
 


### PR DESCRIPTION
<img width="582" height="261" alt="image" src="https://github.com/user-attachments/assets/970807bb-aa39-42a3-8ae7-89cd5e616710" />

New release of cyptominisat doesn't play nice with W11 due to missing dlls 