### PR TITLE
Add Include Ejectors option to export dialog

### DIFF
--- a/src/ApsGenerator.UI/ExportDialog.axaml
+++ b/src/ApsGenerator.UI/ExportDialog.axaml
@@ -16,6 +16,9 @@
                        FormatString="0"
                        Minimum="1" Maximum="8" Value="2" Increment="1" />
 
+		<TextBlock x:Name="ToggleEjectorsLabel" Text="Include Ejectors?" />
+		<CheckBox x:Name="ToggleEjectors" IsChecked="True"></CheckBox>
+
         <TextBlock Text="Bill of Materials" FontWeight="SemiBold" />
         <ItemsControl x:Name="BomList" Margin="8,0,0,0">
             <ItemsControl.ItemTemplate>

--- a/src/ApsGenerator.UI/ExportDialog.axaml.cs
+++ b/src/ApsGenerator.UI/ExportDialog.axaml.cs
@@ -61,6 +61,7 @@ public partial class ExportDialog : Window
             handledEventsToo: true);
         BlueprintNameBox.TextChanged += OnBlueprintNameTextChanged;
         TargetHeightBox.ValueChanged += OnTargetHeightValueChanged;
+        ToggleEjectors.IsCheckedChanged += OnToggleEjectorsChanged;
         hasManualBlueprintNameEdit = false;
         UpdateAutoBlueprintName();
         SaveLocationBox.Text = ResolveDefaultFolder(lastExportFolder);
@@ -149,13 +150,17 @@ public partial class ExportDialog : Window
         hasManualBlueprintNameEdit = true;
     }
 
+    private void OnToggleEjectorsChanged(object? sender, EventArgs e) {
+        UpdateBillOfMaterials();
+    }
+
     private void UpdateBillOfMaterials()
     {
         int targetHeight = (int)(TargetHeightBox.Value ?? 2);
 
         try
         {
-            var previewOptions = new ExportOptions(BlueprintNameBox.Text ?? string.Empty, targetHeight);
+            var previewOptions = new ExportOptions(BlueprintNameBox.Text ?? string.Empty, targetHeight, ToggleEjectors.IsChecked ?? true);
             BlueprintFile previewBlueprint = BlueprintBuilder.Build(placements, grid, tetrisType, previewOptions);
 
             var idToBlock = new Dictionary<int, BlockDefinition>();
@@ -294,6 +299,12 @@ public partial class ExportDialog : Window
             TargetHeightBox.Value = targetHeight;
         }
 
+        if (ToggleEjectors.IsChecked is not bool toggleEjectors)
+        {
+            ShowError("Toggle ejectors must be true or false");
+            return;
+        }
+
         var saveLocation = SaveLocationBox.Text?.Trim();
         if (string.IsNullOrWhiteSpace(saveLocation))
         {
@@ -320,7 +331,7 @@ public partial class ExportDialog : Window
 
         try
         {
-            var options = new ExportOptions(name, targetHeight);
+            var options = new ExportOptions(name, targetHeight, toggleEjectors);
             BlueprintExporter.Export(placements, grid, tetrisType, options, filePath);
             Tag = saveLocation;
             Close(true);

--- a/src/ApsGenerator.UI/Services/Export/BlueprintBuilder.cs
+++ b/src/ApsGenerator.UI/Services/Export/BlueprintBuilder.cs
@@ -100,13 +100,19 @@ internal static class BlueprintBuilder
             int loaderBlr = BlockRotation.FindRotation(LoaderPrimary, loaderTarget, LoaderSecondary, LoaderSecondaryTarget);
             EmitBlock(emittedBlocks, loaderX, 0, loaderZ, loaderKey, loaderBlr);
 
-            if (includeEjectors) {
+            if (includeEjectors)
+            {
                 Vector3 ejectorTarget = type == TetrisType.ThreeClip
                     ? loaderTarget
                     : DefaultEjectorTarget;
                 int ejectorBlr = BlockRotation.FindRotation(EjectorPrimary, ejectorTarget, EjectorSecondary, EjectorSecondaryTarget);
                 EmitBlock(emittedBlocks, loaderX, -1, loaderZ, "Ejector_1", ejectorBlr);
                     ReserveEjectorClearanceCell(reservedIntakePositions, loaderX, loaderZ, ejectorTarget);
+            }
+            else
+            {
+                int intakeBlr = BlockRotation.FindRotation(IntakePrimary, Vector3.UnitY, IntakeSecondary, -Vector3.UnitZ);
+                EmitBlock(emittedBlocks, loaderX, -1, loaderZ, "AmmoIntake_1", intakeBlr, GameData.GetAmmoIntakeBlockData(Vector3.UnitY));
             }
 
             foreach (CellOffset offset in shape.Offsets)

--- a/src/ApsGenerator.UI/Services/Export/BlueprintBuilder.cs
+++ b/src/ApsGenerator.UI/Services/Export/BlueprintBuilder.cs
@@ -53,7 +53,7 @@ internal static class BlueprintBuilder
             if (type == TetrisType.FiveClip)
                 EmitFiveClipBlocks(placements, grid, options.TargetHeight, emittedBlocks);
             else
-                EmitScaleBasicBlocks(placements, grid, type, options.TargetHeight, emittedBlocks);
+                EmitScaleBasicBlocks(placements, grid, type, options.TargetHeight, options.IncludeEjectors, emittedBlocks);
         }
 
         return AssembleBlueprint(options.BlueprintName, options.TargetHeight, emittedBlocks);
@@ -78,6 +78,7 @@ internal static class BlueprintBuilder
         Grid grid,
         TetrisType type,
         int targetHeight,
+        bool includeEjectors,
         Dictionary<(int X, int Y, int Z), EmittedBlock> emittedBlocks)
     {
         IReadOnlyList<ClusterShape> shapes = ClusterShape.GetShapes(type);
@@ -99,12 +100,14 @@ internal static class BlueprintBuilder
             int loaderBlr = BlockRotation.FindRotation(LoaderPrimary, loaderTarget, LoaderSecondary, LoaderSecondaryTarget);
             EmitBlock(emittedBlocks, loaderX, 0, loaderZ, loaderKey, loaderBlr);
 
-            Vector3 ejectorTarget = type == TetrisType.ThreeClip
-                ? loaderTarget
-                : DefaultEjectorTarget;
-            int ejectorBlr = BlockRotation.FindRotation(EjectorPrimary, ejectorTarget, EjectorSecondary, EjectorSecondaryTarget);
-            EmitBlock(emittedBlocks, loaderX, -1, loaderZ, "Ejector_1", ejectorBlr);
-            ReserveEjectorClearanceCell(reservedIntakePositions, loaderX, loaderZ, ejectorTarget);
+            if (includeEjectors) {
+                Vector3 ejectorTarget = type == TetrisType.ThreeClip
+                    ? loaderTarget
+                    : DefaultEjectorTarget;
+                int ejectorBlr = BlockRotation.FindRotation(EjectorPrimary, ejectorTarget, EjectorSecondary, EjectorSecondaryTarget);
+                EmitBlock(emittedBlocks, loaderX, -1, loaderZ, "Ejector_1", ejectorBlr);
+                    ReserveEjectorClearanceCell(reservedIntakePositions, loaderX, loaderZ, ejectorTarget);
+            }
 
             foreach (CellOffset offset in shape.Offsets)
             {

--- a/src/ApsGenerator.UI/Services/Export/ExportOptions.cs
+++ b/src/ApsGenerator.UI/Services/Export/ExportOptions.cs
@@ -1,3 +1,3 @@
 namespace ApsGenerator.UI.Services.Export;
 
-public sealed record ExportOptions(string BlueprintName, int TargetHeight);
+public sealed record ExportOptions(string BlueprintName, int TargetHeight, bool IncludeEjectors);

--- a/tests/ApsGenerator.UI.Tests/BlueprintExportTests.cs
+++ b/tests/ApsGenerator.UI.Tests/BlueprintExportTests.cs
@@ -18,7 +18,7 @@ public sealed class BlueprintExportTests
             Array.Empty<Placement>(),
             grid,
             TetrisType.FourClip,
-            new ExportOptions("empty", TargetHeight: 2));
+            new ExportOptions("empty", TargetHeight: 2, true));
 
         BlueprintFile blueprint = ParseBlueprint(json);
 
@@ -39,7 +39,7 @@ public sealed class BlueprintExportTests
             placements,
             grid,
             TetrisType.FourClip,
-            new ExportOptions("single-four-clip-h2", TargetHeight: 2));
+            new ExportOptions("single-four-clip-h2", TargetHeight: 2, true));
 
         BlueprintFile blueprint = ParseBlueprint(json);
 
@@ -82,7 +82,7 @@ public sealed class BlueprintExportTests
             placements,
             grid,
             TetrisType.FourClip,
-            new ExportOptions("single-four-clip-h1-bottom", TargetHeight: 1));
+            new ExportOptions("single-four-clip-h1-bottom", TargetHeight: 1, true));
 
         BlueprintFile blueprint = ParseBlueprint(json);
 
@@ -123,7 +123,7 @@ public sealed class BlueprintExportTests
             placements,
             grid,
             TetrisType.ThreeClip,
-            new ExportOptions("single-three-clip-h1-bottom", TargetHeight: 1));
+            new ExportOptions("single-three-clip-h1-bottom", TargetHeight: 1, true));
 
         BlueprintFile blueprint = ParseBlueprint(json);
 
@@ -169,7 +169,7 @@ public sealed class BlueprintExportTests
             placements,
             grid,
             TetrisType.ThreeClip,
-            new ExportOptions("single-three-clip-left-bottom", TargetHeight: 1));
+            new ExportOptions("single-three-clip-left-bottom", TargetHeight: 1, true));
 
         BlueprintFile blueprint = ParseBlueprint(json);
 
@@ -197,7 +197,7 @@ public sealed class BlueprintExportTests
             placements,
             grid,
             TetrisType.ThreeClip,
-            new ExportOptions("single-three-clip-h2-cost", TargetHeight: 2));
+            new ExportOptions("single-three-clip-h2-cost", TargetHeight: 2, true));
 
         BlueprintFile blueprint = ParseBlueprint(json);
 
@@ -227,7 +227,7 @@ public sealed class BlueprintExportTests
             placements,
             grid,
             TetrisType.FiveClip,
-            new ExportOptions("shared-connector", TargetHeight: 3));
+            new ExportOptions("shared-connector", TargetHeight: 3, true));
 
         BlueprintFile blueprint = ParseBlueprint(json);
 
@@ -245,7 +245,7 @@ public sealed class BlueprintExportTests
                 placements,
                 grid,
                 TetrisType.FiveClip,
-                new ExportOptions("invalid-five", TargetHeight: 4)));
+                new ExportOptions("invalid-five", TargetHeight: 4, true)));
 
         Assert.Contains("5-clip target height must be a positive multiple of 3 (got 4).", ex.Message);
     }
@@ -260,7 +260,7 @@ public sealed class BlueprintExportTests
             placements,
             grid,
             TetrisType.FourClip,
-            new ExportOptions("block-data-index", TargetHeight: 1));
+            new ExportOptions("block-data-index", TargetHeight: 1, true));
 
         BlueprintFile blueprint = ParseBlueprint(json);
         Assert.NotEmpty(blueprint.Blueprint.BlockData);


### PR DESCRIPTION
Adds a checkbox to toggle if ejectors are included in the exported blueprint. 

The tests seem to all pass, but the test runner crashed after they passed. I don't see why any of my changes would cause that, though.

Fixes #36.